### PR TITLE
chore: bump github-actions-ensure-sha-pinned-actions

### DIFF
--- a/.github/workflows/check-actions.yaml
+++ b/.github/workflows/check-actions.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Ensure SHA pinned actions
-        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@fdc1a0099560840b2be12459d0a61c7bc95b9db1 # v3.0.0
+        uses: zgosalvez/github-actions-ensure-sha-pinned-actions@b35f285b9bb7e80de0967367cee66d3b6d50ceca # v3.0.1
         with:
           # slsa-github-generator requires using a semver tag for reusable workflows. 
           # See: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators


### PR DESCRIPTION
## Explanation

Bump github-actions-ensure-sha-pinned-actions.
