### PR TITLE
fix: violation not visible in json output

### DIFF
--- a/pkg/commands/scan/options.go
+++ b/pkg/commands/scan/options.go
@@ -13,7 +13,6 @@ import (
 	"github.com/kyverno/kyverno-json/pkg/policy"
 	"github.com/kyverno/kyverno/ext/output/pluralize"
 	"github.com/spf13/cobra"
-	"go.uber.org/multierr"
 	"k8s.io/apimachinery/pkg/labels"
 )
 
@@ -89,7 +88,7 @@ func (c *options) run(cmd *cobra.Command, _ []string) error {
 				if rule.Error != nil {
 					out.println("-", policy.Policy.Name, "/", rule.Rule.Name, "/", rule.Identifier, "ERROR:", rule.Error.Error())
 				} else if len(rule.Violations) != 0 {
-					out.println("-", policy.Policy.Name, "/", rule.Rule.Name, "/", rule.Identifier, "FAILED:", multierr.Combine(rule.Violations...).Error())
+					out.println("-", policy.Policy.Name, "/", rule.Rule.Name, "/", rule.Identifier, "FAILED:", strings.Join(rule.Violations, "; "))
 				} else {
 					// TODO: handle skip, warn
 					out.println("-", policy.Policy.Name, "/", rule.Rule.Name, "/", rule.Identifier, "PASSED")

--- a/pkg/json-engine/engine.go
+++ b/pkg/json-engine/engine.go
@@ -32,7 +32,7 @@ type RuleResponse struct {
 	Rule       v1alpha1.ValidatingRule
 	Identifier string
 	Error      error
-	Violations []error
+	Violations []string
 }
 
 // PolicyResult specifies state of a policy result

--- a/pkg/matching/match.go
+++ b/pkg/matching/match.go
@@ -2,7 +2,6 @@ package matching
 
 import (
 	"context"
-	"errors"
 
 	"github.com/jmespath-community/go-jmespath/pkg/binding"
 	"github.com/kyverno/kyverno-json/pkg/apis/policy/v1alpha1"
@@ -11,12 +10,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func MatchAssert(ctx context.Context, path *field.Path, match *v1alpha1.Assert, actual any, bindings binding.Bindings, opts ...template.Option) ([]error, error) {
+func MatchAssert(ctx context.Context, path *field.Path, match *v1alpha1.Assert, actual any, bindings binding.Bindings, opts ...template.Option) ([]string, error) {
 	if match == nil || (len(match.Any) == 0 && len(match.All) == 0) {
 		return nil, field.Invalid(path, match, "an empty assert is not valid")
 	} else {
 		if len(match.Any) != 0 {
-			var fails []error
+			var fails []string
 			path := path.Child("any")
 			for i, assertion := range match.Any {
 				checkFails, err := assert.Assert(ctx, path.Index(i).Child("check"), assert.Parse(ctx, assertion.Check.Value), actual, bindings, opts...)
@@ -30,9 +29,9 @@ func MatchAssert(ctx context.Context, path *field.Path, match *v1alpha1.Assert, 
 				if assertion.Message != "" {
 					msg := template.String(ctx, assertion.Message, actual, bindings, opts...)
 					msg += ": " + checkFails.ToAggregate().Error()
-					fails = append(fails, errors.New(msg))
+					fails = append(fails, msg)
 				} else {
-					fails = append(fails, checkFails.ToAggregate())
+					fails = append(fails, checkFails.ToAggregate().Error())
 				}
 			}
 			if fails != nil {
@@ -40,7 +39,7 @@ func MatchAssert(ctx context.Context, path *field.Path, match *v1alpha1.Assert, 
 			}
 		}
 		if len(match.All) != 0 {
-			var fails []error
+			var fails []string
 			path := path.Child("all")
 			for i, assertion := range match.All {
 				checkFails, err := assert.Assert(ctx, path.Index(i).Child("check"), assert.Parse(ctx, assertion.Check.Value), actual, bindings, opts...)
@@ -51,9 +50,9 @@ func MatchAssert(ctx context.Context, path *field.Path, match *v1alpha1.Assert, 
 					if assertion.Message != "" {
 						msg := template.String(ctx, assertion.Message, actual, bindings, opts...)
 						msg += ": " + checkFails.ToAggregate().Error()
-						fails = append(fails, errors.New(msg))
+						fails = append(fails, msg)
 					} else {
-						fails = append(fails, checkFails.ToAggregate())
+						fails = append(fails, checkFails.ToAggregate().Error())
 					}
 				}
 			}

--- a/pkg/server/model/response.go
+++ b/pkg/server/model/response.go
@@ -1,8 +1,9 @@
 package model
 
 import (
+	"strings"
+
 	jsonengine "github.com/kyverno/kyverno-json/pkg/json-engine"
-	"go.uber.org/multierr"
 )
 
 type Response struct {
@@ -51,7 +52,7 @@ func makeMessage(rule jsonengine.RuleResponse) string {
 		return rule.Error.Error()
 	}
 	if len(rule.Violations) != 0 {
-		return multierr.Combine(rule.Violations...).Error()
+		return strings.Join(rule.Violations, "; ")
 	}
 	return ""
 }

--- a/test/api/go/main/main.go
+++ b/test/api/go/main/main.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"log"
+	"strings"
 
 	jsonengine "github.com/kyverno/kyverno-json/pkg/json-engine"
 	"github.com/kyverno/kyverno-json/pkg/policy"
-	"go.uber.org/multierr"
 )
 
 const policyYAML = `
@@ -70,7 +70,7 @@ func main() {
 			if rule.Error != nil {
 				logger.Printf("error: %s/%s -> %s: %s", policy.Policy.Name, rule.Rule.Name, rule.Identifier, rule.Error)
 			} else if len(rule.Violations) != 0 {
-				logger.Printf("fail: %s/%s -> %s: %s", policy.Policy.Name, rule.Rule.Name, rule.Identifier, multierr.Combine(rule.Violations...))
+				logger.Printf("fail: %s/%s -> %s: %s", policy.Policy.Name, rule.Rule.Name, rule.Identifier, strings.Join(rule.Violations, "; "))
 			} else {
 				logger.Printf("pass: %s/%s -> %s", policy.Policy.Name, rule.Rule.Name, rule.Identifier)
 			}


### PR DESCRIPTION
## Explanation
Violations were not visible in json output because errors are parsed as `{}`. This PR converts violation from array of errors to array of strings, Violations are now visible.
<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->

## What type of PR is this

<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

**nNOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.

-->

### Proof Manifests
Current behaviour:
```
"Rules": [
                  {
                    "Rule": {
                      "name": "detect-untrusted-flag",
                      "match": {
                        "any": [
                          {
                            "(Stages[].Commands[?Name=='RUN'].CmdLine[][] | length(@) \u003e `0`)": true
                          }
                        ]
                      },
                      "assert": {
                        "any": [
                          {
                            "message": "Dockerfile contains the '--allow-untrusted' which is not preferred",
                            "check": {
                              "~.(Stages[].Commands[?Name=='RUN'].CmdLine[][])": {
                                "(contains(@, '--allow-untrusted') \u0026\u0026 (contains(@, 'apk')))": false
                              }
                            }
                          }
                        ]
                      }
                    },
                    "Identifier": "",
                    "Error": null,
                    "Violations": [
                      {}
                    ]
                  }
                ]
              }
            ]
          }
```
Updated behaviour:
```bash
❯ ./../../../../kyverno-json scan --policy ./policy.yaml --payload ./payload.json --output json
....
        "Rules": [
          {
            "Rule": {
              "name": "deny-external-calls",
              "assert": {
                "all": [
                  {
                    "message": "HTTP calls are not allowed",
                    "check": {
                      "~.(Stages[].Commands[].Args[].Value)": {
                        "(contains(@, 'https://') || contains(@, 'http://'))": false
                      }
                    }
                  },
                  {
                    "message": "HTTP calls are not allowed",
                    "check": {
                      "~.(Stages[].Commands[].CmdLine[])": {
                        "(contains(@, 'https://') || contains(@, 'http://'))": false
                      }
                    }
                  },
                  {
                    "message": "curl is not allowed",
                    "check": {
                      "~.(Stages[].Commands[].CmdLine[])": {
                        "(contains(@, 'curl'))": false
                      }
                    }
                  },
                  {
                    "message": "wget is not allowed",
                    "check": {
                      "~.(Stages[].Commands[].CmdLine[])": {
                        "(contains(@, 'wget'))": false
                      }
                    }
                  }
                ]
              }
            },
            "Identifier": "",
            "Error": null,
            "Violations": [
              "HTTP calls are not allowed: all[0].check.~.(Stages[].Commands[].Args[].Value)[0].(contains(@, 'https://') || contains(@, 'http://')): Invalid value: true: Expected value: false",
              "wget is not allowed: all[3].check.~.(Stages[].Commands[].CmdLine[])[0].(contains(@, 'wget')): Invalid value: true: Expected value: false"
            ]
          }
        ]
      }
    ]
  }
]
```

<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ ] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.

## Further Comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
