### PR TITLE
Added unit tests for payload file

### DIFF
--- a/pkg/payload/load_test.go
+++ b/pkg/payload/load_test.go
@@ -1,0 +1,44 @@
+package payload
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoad(t *testing.T) {
+	basePath := "../../test/commands/scan"
+	tests := []struct {
+		name    string
+		path    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid JSON File",
+			path:    filepath.Join(basePath, "/tf-ec2/payload.json"),
+			wantErr: false,
+		},
+		{
+			name:    "Valid YAML File",
+			path:    filepath.Join(basePath, "/pod-no-latest/payload.yaml"),
+			wantErr: false,
+		},
+		{
+			name:    "Not a YAML or a JSON File",
+			path:    filepath.Join(basePath, "/dockerfile/out.txt"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := Load(tt.path)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

Added some basic unit tests for the file that loads the JSON or YAML file provided. 

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->

## Related issue
#22
<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->

## Milestone of this PR
`/milestone 0.3.0`


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [ ] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.

## Further Comments

I wanted to add more test cases to the test file. 

- Check whether an error is reported when an invalid JSON or YAML file is provided
- Check whether the function parses a YAML file properly when two definitions are provided and separated using `---`.

As of now, I have used existing payload files from `test/commands/scan` directory but I could not find payload files that represented the above cases. 
Any direction on this?