### PR TITLE
fix: deep copy Any objects

### DIFF
--- a/pkg/apis/policy/v1alpha1/any.go
+++ b/pkg/apis/policy/v1alpha1/any.go
@@ -17,7 +17,7 @@ type Any struct {
 }
 
 func (in *Any) DeepCopyInto(out *Any) {
-	if err := copier.Copy(out, in); err != nil {
+	if err := copier.CopyWithOption(out, in, copier.Option{DeepCopy: true}); err != nil {
 		panic("deep copy failed")
 	}
 }

--- a/pkg/apis/policy/v1alpha1/any_test.go
+++ b/pkg/apis/policy/v1alpha1/any_test.go
@@ -34,6 +34,17 @@ func TestAny_DeepCopyInto(t *testing.T) {
 			assert.Equal(t, tt.in, tt.out)
 		})
 	}
+	{
+		inner := map[string]any{
+			"foo": 42,
+		}
+		in := Any{map[string]any{"inner": inner}}
+		out := in.DeepCopy()
+		inPtr := in.Value.(map[string]any)["inner"].(map[string]any)
+		inPtr["foo"] = 55
+		outPtr := out.Value.(map[string]any)["inner"].(map[string]any)
+		assert.NotEqual(t, inPtr, outPtr)
+	}
 }
 
 func TestAny_MarshalJSON(t *testing.T) {


### PR DESCRIPTION
## Explanation

Fix deep copy `Any` objects.
