### PR TITLE
fix: use ; as engine separator

### DIFF
--- a/pkg/syntax/expression/expression.go
+++ b/pkg/syntax/expression/expression.go
@@ -8,7 +8,7 @@ var (
 	foreachRegex = regexp.MustCompile(`^~(\w+)?\.(.*)`)
 	bindingRegex = regexp.MustCompile(`(.*)\s*->\s*(\w+)$`)
 	escapeRegex  = regexp.MustCompile(`^\\(.+)\\$`)
-	engineRegex  = regexp.MustCompile(`^\((?:(\w+):)?(.+)\)$`)
+	engineRegex  = regexp.MustCompile(`^\((?:(\w+);)?(.+)\)$`)
 )
 
 const (


### PR DESCRIPTION
## Explanation

Use `;` as engine separator.
