### PR TITLE
test for 'serve' command flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .gopath/
 .tools/
 .venv/
+.idea/
 coverage.out
 dist/
 /kyverno-json

--- a/pkg/commands/serve/command_test.go
+++ b/pkg/commands/serve/command_test.go
@@ -1,0 +1,44 @@
+package serve_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/kyverno/kyverno-json/pkg/commands/serve"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CommandFlags(t *testing.T) {
+	cmd := serve.Command()
+	require.NotNil(t, cmd, fmt.Sprintf("%s command should not be nil", cmd.Use))
+
+	tests := []struct {
+		flagName     string
+		defaultValue string
+		userValue    string
+	}{
+		{"server-host", "0.0.0.0", "127.0.0.1"},
+		{"server-port", "8080", "9090"},
+		{"gin-mode", gin.ReleaseMode, gin.DebugMode},
+		{"gin-log", "true", "false"},
+		{"gin-cors", "true", "false"},
+		{"gin-max-body-size", "2097152" /* 2MB, 2 * 1024 * 1024 */, "1048576" /* 1MB, 1 * 1024 * 1024 */},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.flagName, func(t *testing.T) {
+			flag := cmd.Flags().Lookup(tt.flagName)
+			require.NotNil(t, flag, "Flag should be defined")
+			assert.Equal(t, tt.defaultValue, flag.DefValue, "Default value should match")
+
+			/* Set the flag to the user-defined value */
+			err := cmd.Flags().Set(tt.flagName, tt.userValue)
+			require.NoError(t, err, "Setting flag should not return an error")
+
+			/* Verify the flag is set to the user-defined value */
+			assert.Equal(t, tt.userValue, flag.Value.String(), "User-defined value should match")
+		})
+	}
+}


### PR DESCRIPTION
## Explanation

<!--
In a couple sentences, explain why this PR is needed and what it addresses. This should be an explanation a non-developer user can understand and covers the "why" question. It should also clearly indicate whether this PR represents an addition, a change, or a fix of existing behavior. This explanation will be used to assist in the release note drafting process.

THIS IS MANDATORY.
-->
This PR adds test coverage for command flags in the serve package. It validates both default values and user-defined values for server configuration flags including host, port, gin mode, logging, CORS, and max body size settings.

## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `Closes #1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@JimBugwadia`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers in the [Kyverno Slack Channel](https://kubernetes.slack.com/).
-->
#22 
## Milestone of this PR
<!--

Add the milestone label by commenting `/milestone 1.2.3`.

-->
`/milestone 0.3.0`


<!--

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading white spaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
-->



<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. 

**nNOTE***: If this PR results in new or altered behavior which is user facing, you **MUST** read and follow the steps outlined in the [PR documentation guide](pr_documentation.md) and add Proof Manifests as defined below.

-->



<!--
Read and follow the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) for more details first. This section is for pasting your YAML manifests (Kubernetes resources and Kyverno policies) which allow maintainers to prove the intended functionality is achieved by your PR. Please use proper fenced code block formatting, for example:

# Kubernetes resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: roles-dictionary
  namespace: default
data:
  allowed-roles: "[\"cluster-admin\", \"cluster-operator\", \"tenant-admin\"]"
```
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [ ] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.

