### PR TITLE
Feat/462 configmap context

### DIFF
--- a/.schemas/json/_definitions.json
+++ b/.schemas/json/_definitions.json
@@ -17753,6 +17753,24 @@
                             "cel"
                           ]
                         },
+                        "configMap": {
+                          "description": "ConfigMap allows referencing a ConfigMap as data source.",
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "namespace"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "Name is the ConfigMap name.",
+                              "type": "string"
+                            },
+                            "namespace": {
+                              "description": "Namespace is the ConfigMap namespace.",
+                              "type": "string"
+                            }
+                          }
+                        },
                         "name": {
                           "description": "Name is the entry name.",
                           "type": "string"

--- a/.schemas/json/validatingpolicy-json-v1alpha1.json
+++ b/.schemas/json/validatingpolicy-json-v1alpha1.json
@@ -439,6 +439,27 @@
                     "compiler": {
                       "description": "Compiler defines the default compiler to use when evaluating expressions.",
                       "type": [
+                    "configMap": {
+                      "description": "ConfigMap allows referencing a ConfigMap as data source.",
+                      "type": [
+                        "object",
+                        "null"
+                      ],
+                      "required": [
+                        "name",
+                        "namespace"
+                      ],
+                      "properties": {
+                        "name": {
+                          "description": "Name is the ConfigMap name.",
+                          "type": "string"
+                        },
+                        "namespace": {
+                          "description": "Namespace is the ConfigMap namespace.",
+                          "type": "string"
+                        }
+                      }
+                    },
                         "string",
                         "null"
                       ],

--- a/.schemas/json/validatingpolicylist-json-v1alpha1.json
+++ b/.schemas/json/validatingpolicylist-json-v1alpha1.json
@@ -457,6 +457,27 @@
                         ],
                         "required": [
                           "name"
+                          "configMap": {
+                            "description": "ConfigMap allows referencing a ConfigMap as data source.",
+                            "type": [
+                              "object",
+                              "null"
+                            ],
+                            "required": [
+                              "name",
+                              "namespace"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "Name is the ConfigMap name.",
+                                "type": "string"
+                              },
+                              "namespace": {
+                                "description": "Namespace is the ConfigMap namespace.",
+                                "type": "string"
+                              }
+                            }
+                          },
                         ],
                         "properties": {
                           "compiler": {

--- a/pkg/apis/policy/v1alpha1/context_entry.go
+++ b/pkg/apis/policy/v1alpha1/context_entry.go
@@ -12,4 +12,17 @@ type ContextEntry struct {
 	// Variable defines an arbitrary variable.
 	// +optional
 	Variable Any `json:"variable,omitempty"`
+
+	// ConfigMap allows referencing a ConfigMap as data source.
+	// +optional
+	ConfigMap *ConfigMapReference `json:"configMap,omitempty"`
+}
+
+// ConfigMapReference references a ConfigMap resource.
+type ConfigMapReference struct {
+	// Name is the ConfigMap name.
+	Name string `json:"name"`
+
+	// Namespace is the ConfigMap namespace.
+	Namespace string `json:"namespace"`
 }

--- a/pkg/client/configmap/client.go
+++ b/pkg/client/configmap/client.go
@@ -1,0 +1,40 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Client provides functions to interact with ConfigMaps
+type Client interface {
+	// Get fetches a ConfigMap from the Kubernetes API server
+	Get(ctx context.Context, name, namespace string) (*v1.ConfigMap, error)
+}
+
+// client implements the Client interface
+type client struct {
+	clientset kubernetes.Interface
+}
+
+// NewClient creates a new instance of the ConfigMap client
+func NewClient(clientset kubernetes.Interface) Client {
+	return &client{
+		clientset: clientset,
+	}
+}
+
+// Get retrieves a ConfigMap from the API server
+func (c *client) Get(ctx context.Context, name, namespace string) (*v1.ConfigMap, error) {
+	if name == "" {
+		return nil, fmt.Errorf("ConfigMap name cannot be empty")
+	}
+	if namespace == "" {
+		return nil, fmt.Errorf("ConfigMap namespace cannot be empty")
+	}
+
+	return c.clientset.CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
+}

--- a/pkg/client/configmap/client_test.go
+++ b/pkg/client/configmap/client_test.go
@@ -1,0 +1,159 @@
+package configmap
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestConfigMapClient(t *testing.T) {
+	// Create a fake clientset
+	clientset := fake.NewSimpleClientset()
+
+	// Create a test ConfigMap
+	testConfigMap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"key1": "value1",
+			"key2": "value2",
+		},
+	}
+
+	// Add the ConfigMap to the fake clientset
+	_, err := clientset.CoreV1().ConfigMaps("default").Create(context.Background(), testConfigMap, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test ConfigMap: %v", err)
+	}
+
+	// Create the ConfigMap client
+	client := NewClient(clientset)
+
+	// Test cases
+	tests := []struct {
+		name          string
+		namespace     string
+		configMapName string
+		wantErr       bool
+		checkData     bool
+	}{
+		{
+			name:          "Get existing ConfigMap",
+			namespace:     "default",
+			configMapName: "test-configmap",
+			wantErr:       false,
+			checkData:     true,
+		},
+		{
+			name:          "ConfigMap not found",
+			namespace:     "default",
+			configMapName: "non-existent",
+			wantErr:       true,
+			checkData:     false,
+		},
+		{
+			name:          "Invalid namespace",
+			namespace:     "",
+			configMapName: "test-configmap",
+			wantErr:       true,
+			checkData:     false,
+		},
+		{
+			name:          "Invalid name",
+			namespace:     "default",
+			configMapName: "",
+			wantErr:       true,
+			checkData:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm, err := client.Get(context.Background(), tt.configMapName, tt.namespace)
+
+			// Check error expectation
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Get() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// Don't check data if we expected an error
+			if tt.wantErr {
+				return
+			}
+
+			// Verify ConfigMap data
+			if tt.checkData {
+				if cm == nil {
+					t.Fatal("Expected ConfigMap to be non-nil")
+				}
+
+				if cm.Name != tt.configMapName {
+					t.Errorf("Expected ConfigMap name %s, got %s", tt.configMapName, cm.Name)
+				}
+
+				if cm.Namespace != tt.namespace {
+					t.Errorf("Expected ConfigMap namespace %s, got %s", tt.namespace, cm.Namespace)
+				}
+
+				// Check data entries
+				if val, ok := cm.Data["key1"]; !ok || val != "value1" {
+					t.Errorf("Expected cm.Data[\"key1\"] = \"value1\", got %s", val)
+				}
+
+				if val, ok := cm.Data["key2"]; !ok || val != "value2" {
+					t.Errorf("Expected cm.Data[\"key2\"] = \"value2\", got %s", val)
+				}
+			}
+		})
+	}
+}
+
+// TestMockConfigMapClient creates a mock client for testing
+func TestMockConfigMapClient(t *testing.T) {
+	mockClient := &mockClient{}
+
+	configMap, err := mockClient.Get(context.Background(), "any-name", "any-namespace")
+	if err != nil {
+		t.Fatalf("Expected no error from mock client, got: %v", err)
+	}
+
+	if configMap == nil {
+		t.Fatal("Expected ConfigMap to be non-nil")
+	}
+
+	// Check that the mock returned the expected values
+	if configMap.Name != "any-name" {
+		t.Errorf("Expected ConfigMap name to be \"any-name\", got %s", configMap.Name)
+	}
+
+	if configMap.Namespace != "any-namespace" {
+		t.Errorf("Expected ConfigMap namespace to be \"any-namespace\", got %s", configMap.Namespace)
+	}
+
+	// Check data
+	if _, ok := configMap.Data["test-key"]; !ok {
+		t.Error("Expected configMap.Data to contain \"test-key\"")
+	}
+}
+
+// mockClient is a simple mock implementation for testing
+type mockClient struct{}
+
+// Get implements the Client interface
+func (m *mockClient) Get(ctx context.Context, name, namespace string) (*v1.ConfigMap, error) {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"test-key": "test-value",
+		},
+	}, nil
+}

--- a/pkg/commands/serve/options.go
+++ b/pkg/commands/serve/options.go
@@ -8,11 +8,14 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/kyverno/kyverno-json/pkg/client/clientset/versioned"
+	"github.com/kyverno/kyverno-json/pkg/client/configmap"
+	jsonengine "github.com/kyverno/kyverno-json/pkg/json-engine"
 	"github.com/kyverno/kyverno-json/pkg/server"
 	"github.com/kyverno/kyverno-json/pkg/server/scan"
 	restutils "github.com/kyverno/kyverno-json/pkg/utils/rest"
 	"github.com/loopfz/gadgeto/tonic"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -51,6 +54,18 @@ func (c *options) Run(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+
+	// Initialize Kubernetes clientset
+	k8sClientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	// Initialize ConfigMap client and set it in the JSONEngine
+	configMapClient := configmap.NewClient(k8sClientset)
+	jsonengine.SetConfigMapClient(configMapClient)
+
+	// Initialize Kyverno JSON clientset
 	client, err := versioned.NewForConfig(restConfig)
 	if err != nil {
 		return err

--- a/pkg/engine/blocks/constant/constant_test.go
+++ b/pkg/engine/blocks/constant/constant_test.go
@@ -1,0 +1,75 @@
+package constant
+
+import (
+	"context"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+// Test types for generic engine
+type TestRequest struct {
+	Input string
+}
+
+type TestResponse struct {
+	Output string
+}
+
+func Test_Constant(t *testing.T) {
+	// Test creating a constant engine with a predefined response
+	expectedResponse := TestResponse{Output: "test output"}
+	engine := New[TestRequest, TestResponse](expectedResponse)
+
+	// Test that Run returns the constant response regardless of the input
+	testCases := []struct {
+		name    string
+		request TestRequest
+	}{
+		{
+			name:    "empty request",
+			request: TestRequest{},
+		},
+		{
+			name:    "non-empty request",
+			request: TestRequest{Input: "test input"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run with different requests should always return the same response
+			response := engine.Run(context.Background(), tc.request)
+
+			// Verify the response matches the expected constant value
+			assert.Equal(t, expectedResponse.Output, response.Output)
+		})
+	}
+}
+
+// Test with primitive types
+func Test_ConstantWithPrimitives(t *testing.T) {
+	// Test with string
+	stringEngine := New[int, string]("constant string")
+	stringResponse := stringEngine.Run(context.Background(), 42)
+	assert.Equal(t, "constant string", stringResponse)
+
+	// Test with int
+	intEngine := New[string, int](100)
+	intResponse := intEngine.Run(context.Background(), "any input")
+	assert.Equal(t, 100, intResponse)
+
+	// Test with bool
+	boolEngine := New[float64, bool](true)
+	boolResponse := boolEngine.Run(context.Background(), 3.14)
+	assert.Equal(t, true, boolResponse)
+}
+
+// Test with nil value
+func Test_ConstantWithNil(t *testing.T) {
+	// Create engine with nil map
+	var nilMap map[string]interface{}
+	mapEngine := New[string, map[string]interface{}](nilMap)
+	mapResponse := mapEngine.Run(context.Background(), "any input")
+	assert.Assert(t, mapResponse == nil)
+}

--- a/pkg/engine/blocks/function/function_test.go
+++ b/pkg/engine/blocks/function/function_test.go
@@ -1,0 +1,128 @@
+package function
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+// Test types for generic engine
+type TestRequest struct {
+	Input string
+}
+
+type TestResponse struct {
+	Output string
+}
+
+func Test_Function(t *testing.T) {
+	// Define a function that transforms a request into a response
+	processingFunc := func(ctx context.Context, request TestRequest) TestResponse {
+		return TestResponse{
+			Output: "Processed: " + request.Input,
+		}
+	}
+
+	// Create the function engine
+	engine := New[TestRequest, TestResponse](processingFunc)
+
+	// Test cases
+	testCases := []struct {
+		name     string
+		request  TestRequest
+		expected TestResponse
+	}{
+		{
+			name:     "empty input",
+			request:  TestRequest{Input: ""},
+			expected: TestResponse{Output: "Processed: "},
+		},
+		{
+			name:     "non-empty input",
+			request:  TestRequest{Input: "hello"},
+			expected: TestResponse{Output: "Processed: hello"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run with context and request
+			response := engine.Run(context.Background(), tc.request)
+
+			// Verify the response
+			assert.Equal(t, tc.expected.Output, response.Output)
+		})
+	}
+}
+
+// Test with primitive types
+func Test_FunctionWithPrimitives(t *testing.T) {
+	// Test with int to string conversion
+	intToStringFunc := func(ctx context.Context, n int) string {
+		return "Number: " + strconv.Itoa(n)
+	}
+	intToStringEngine := New[int, string](intToStringFunc)
+	result := intToStringEngine.Run(context.Background(), 42)
+	assert.Equal(t, "Number: 42", result)
+
+	// Test with string to int conversion
+	stringToIntFunc := func(ctx context.Context, s string) int {
+		val, _ := strconv.Atoi(s)
+		return val * 2
+	}
+	stringToIntEngine := New[string, int](stringToIntFunc)
+	resultInt := stringToIntEngine.Run(context.Background(), "21")
+	assert.Equal(t, 42, resultInt)
+
+	// Test with context usage
+	contextAwareFunc := func(ctx context.Context, s string) bool {
+		value := ctx.Value("key")
+		return value == s
+	}
+
+	contextAwareEngine := New[string, bool](contextAwareFunc)
+
+	// Create context with value
+	ctxWithValue := context.WithValue(context.Background(), "key", "match")
+
+	// Should match
+	resultTrue := contextAwareEngine.Run(ctxWithValue, "match")
+	assert.Equal(t, true, resultTrue)
+
+	// Should not match
+	resultFalse := contextAwareEngine.Run(ctxWithValue, "no match")
+	assert.Equal(t, false, resultFalse)
+}
+
+// Test with complex data transformations
+func Test_FunctionWithComplexTransformations(t *testing.T) {
+	// Map transformation function
+	mapTransformFunc := func(ctx context.Context, input map[string]interface{}) map[string]interface{} {
+		result := make(map[string]interface{})
+		for k, v := range input {
+			// Transform each value by appending "-transformed"
+			if strVal, ok := v.(string); ok {
+				result[k] = strVal + "-transformed"
+			} else {
+				result[k] = v
+			}
+		}
+		return result
+	}
+
+	mapEngine := New[map[string]interface{}, map[string]interface{}](mapTransformFunc)
+
+	inputMap := map[string]interface{}{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": 123,
+	}
+
+	resultMap := mapEngine.Run(context.Background(), inputMap)
+
+	assert.Equal(t, "value1-transformed", resultMap["key1"].(string))
+	assert.Equal(t, "value2-transformed", resultMap["key2"].(string))
+	assert.Equal(t, 123, resultMap["key3"].(int))
+}

--- a/pkg/json-engine/compiler.go
+++ b/pkg/json-engine/compiler.go
@@ -1,15 +1,25 @@
 package jsonengine
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/jmespath-community/go-jmespath/pkg/binding"
 	"github.com/kyverno/kyverno-json/pkg/apis/policy/v1alpha1"
+	"github.com/kyverno/kyverno-json/pkg/client/configmap"
 	"github.com/kyverno/kyverno-json/pkg/core/compilers"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
+
+// configMapClient is the client used to retrieve ConfigMaps
+var configMapClient configmap.Client
+
+// SetConfigMapClient sets the ConfigMap client
+func SetConfigMapClient(client configmap.Client) {
+	configMapClient = client
+}
 
 func CompileContextEntry(
 	path *field.Path,
@@ -19,24 +29,97 @@ func CompileContextEntry(
 	if in.Compiler != nil {
 		compilers = compilers.WithDefaultCompiler(string(*in.Compiler))
 	}
-	handler, err := in.Variable.Compile(path.Child("variable"), compilers)
-	if err != nil {
-		return nil, err
+
+	// Handle ConfigMap references
+	if in.ConfigMap != nil {
+		if configMapClient == nil {
+			return nil, field.Invalid(path.Child("configMap"), in.ConfigMap, "ConfigMap client not initialized")
+		}
+
+		return func(resource any, bindings binding.Bindings) binding.Bindings {
+			binding := binding.NewDelegate(
+				sync.OnceValues(
+					func() (any, error) {
+						// Fetch the ConfigMap
+						configMap, err := configMapClient.Get(
+							context.Background(),
+							in.ConfigMap.Name,
+							in.ConfigMap.Namespace,
+						)
+						if err != nil {
+							return nil, field.InternalError(path.Child("configMap"), err)
+						}
+
+						// Convert to a map that includes .data and .metadata
+						result := map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name":      configMap.Name,
+								"namespace": configMap.Namespace,
+							},
+							"data": toMap(configMap.Data),
+						}
+
+						// Include binary data if available
+						if len(configMap.BinaryData) > 0 {
+							result["binaryData"] = toMapBinary(configMap.BinaryData)
+						}
+
+						return result, nil
+					},
+				),
+			)
+			return bindings.Register("$"+in.Name, binding)
+		}, nil
 	}
-	return func(resource any, bindings binding.Bindings) binding.Bindings {
-		binding := binding.NewDelegate(
-			sync.OnceValues(
-				func() (any, error) {
-					projected, err := handler(resource, bindings)
-					if err != nil {
-						return nil, field.InternalError(path.Child("variable"), err)
-					}
-					return projected, nil
-				},
-			),
-		)
-		return bindings.Register("$"+in.Name, binding)
-	}, nil
+
+	// Handle variable as before
+	if !in.Variable.IsNil() {
+		handler, err := in.Variable.Compile(path.Child("variable"), compilers)
+		if err != nil {
+			return nil, err
+		}
+		return func(resource any, bindings binding.Bindings) binding.Bindings {
+			binding := binding.NewDelegate(
+				sync.OnceValues(
+					func() (any, error) {
+						projected, err := handler(resource, bindings)
+						if err != nil {
+							return nil, field.InternalError(path.Child("variable"), err)
+						}
+						return projected, nil
+					},
+				),
+			)
+			return bindings.Register("$"+in.Name, binding)
+		}, nil
+	}
+
+	// If neither ConfigMap nor Variable is set, return an error
+	return nil, field.Invalid(path, in, "either variable or configMap must be specified")
+}
+
+// toMap converts a map[string]string to map[string]interface{}
+func toMap(in map[string]string) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// toMap converts a map[string][]byte to map[string]interface{}
+func toMapBinary(in map[string][]byte) map[string]interface{} {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]interface{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 func CompileContextEntries(

--- a/pkg/json-engine/compiler_test.go
+++ b/pkg/json-engine/compiler_test.go
@@ -1,0 +1,150 @@
+package jsonengine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmespath-community/go-jmespath/pkg/binding"
+	"github.com/kyverno/kyverno-json/pkg/apis/policy/v1alpha1"
+	"github.com/kyverno/kyverno-json/pkg/core/compilers"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// mockConfigMapClient is a mock client for testing
+type mockConfigMapClient struct{}
+
+// Get returns a mock ConfigMap for testing
+func (m *mockConfigMapClient) Get(ctx context.Context, name, namespace string) (*v1.ConfigMap, error) {
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"environment": "production",
+			"maxReplicas": "5",
+		},
+	}, nil
+}
+
+// TestConfigMapContextEntry tests the ConfigMap context entry functionality
+func TestConfigMapContextEntry(t *testing.T) {
+	// Set the mock ConfigMap client
+	SetConfigMapClient(&mockConfigMapClient{})
+
+	// Create a context entry that references a ConfigMap
+	contextEntry := v1alpha1.ContextEntry{
+		Name: "testConfig",
+		ConfigMap: &v1alpha1.ConfigMapReference{
+			Name:      "test-configmap",
+			Namespace: "default",
+		},
+	}
+
+	// Create compilers and path for testing
+	compilers := compilers.DefaultCompilers
+	path := field.NewPath("test")
+
+	// Test compiling the context entry
+	contextHandler, err := CompileContextEntry(path, compilers, contextEntry)
+	if err != nil {
+		t.Fatalf("Failed to compile ConfigMap context entry: %v", err)
+	}
+
+	// Create bindings and sample resource
+	bindings := binding.NewBindings()
+	resource := map[string]interface{}{"sample": "data"}
+
+	// Apply the context handler to update bindings
+	updatedBindings := contextHandler(resource, bindings)
+
+	// Create a simple JMESPath expression to test accessing the ConfigMap data
+	jp := compilers.Jp
+
+	// Test accessing the ConfigMap name
+	nameExpr, compileErr := jp.Compile("$testConfig.metadata.name")
+	if compileErr != nil {
+		t.Fatalf("Failed to compile JMESPath expression: %v", compileErr)
+	}
+
+	nameValue, evalErr := nameExpr(resource, updatedBindings)
+	if evalErr != nil {
+		t.Fatalf("Failed to evaluate expression: %v", evalErr)
+	}
+
+	if nameValue != "test-configmap" {
+		t.Errorf("Expected ConfigMap name to be 'test-configmap', got %v", nameValue)
+	}
+
+	// Test accessing ConfigMap data
+	envExpr, compileErr := jp.Compile("$testConfig.data.environment")
+	if compileErr != nil {
+		t.Fatalf("Failed to compile JMESPath expression: %v", compileErr)
+	}
+
+	envValue, evalErr := envExpr(resource, updatedBindings)
+	if evalErr != nil {
+		t.Fatalf("Failed to evaluate expression: %v", evalErr)
+	}
+
+	if envValue != "production" {
+		t.Errorf("Expected environment to be 'production', got %v", envValue)
+	}
+}
+
+func TestCompileContextEntry_NoClient(t *testing.T) {
+	// Reset the client to nil
+	SetConfigMapClient(nil)
+
+	// Create a context entry with ConfigMap reference
+	contextEntry := v1alpha1.ContextEntry{
+		Name: "config",
+		ConfigMap: &v1alpha1.ConfigMapReference{
+			Name:      "test-config",
+			Namespace: "default",
+		},
+	}
+
+	// Create field path and compilers
+	path := field.NewPath("test")
+	compilers := compilers.DefaultCompilers
+
+	// Compile the context entry - should fail because client is nil
+	_, err := CompileContextEntry(path, compilers, contextEntry)
+	if err == nil {
+		t.Fatal("Expected error when ConfigMap client is nil, got nil")
+	}
+
+	// Restore the mock client for other tests
+	SetConfigMapClient(&mockConfigMapClient{})
+}
+
+// TestConfigMapContextEntry_NoClient tests that an error is returned when the ConfigMap client is nil
+func TestConfigMapContextEntry_NoClient(t *testing.T) {
+	// Reset the client to nil
+	SetConfigMapClient(nil)
+
+	// Create a context entry that references a ConfigMap
+	contextEntry := v1alpha1.ContextEntry{
+		Name: "testConfig",
+		ConfigMap: &v1alpha1.ConfigMapReference{
+			Name:      "test-configmap",
+			Namespace: "default",
+		},
+	}
+
+	// Create compilers and path for testing
+	compilers := compilers.DefaultCompilers
+	path := field.NewPath("test")
+
+	// Test compiling the context entry - should fail
+	_, err := CompileContextEntry(path, compilers, contextEntry)
+	if err == nil {
+		t.Fatal("Expected error when ConfigMap client is nil, got nil")
+	}
+
+	// Restore the mock client for other tests
+	SetConfigMapClient(&mockConfigMapClient{})
+}

--- a/pkg/payload/load_test.go
+++ b/pkg/payload/load_test.go
@@ -1,0 +1,101 @@
+package payload
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func Test_Load(t *testing.T) {
+	// Create a temporary directory for test files
+	tempDir, err := os.MkdirTemp("", "payload-test")
+	assert.NilError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Test 1: Load JSON file
+	jsonContent := `{"name": "test", "string_value": "hello"}`
+	jsonPath := filepath.Join(tempDir, "test.json")
+	err = os.WriteFile(jsonPath, []byte(jsonContent), 0644)
+	assert.NilError(t, err)
+
+	result, err := Load(jsonPath)
+	assert.NilError(t, err)
+	resultMap, ok := result.(map[string]interface{})
+	assert.Assert(t, ok, "expected map[string]interface{} for JSON result")
+	assert.Equal(t, "test", resultMap["name"])
+	assert.Equal(t, "hello", resultMap["string_value"])
+
+	// Test 2: Load single document YAML file
+	yamlContent := `name: test
+string_value: hello`
+	yamlPath := filepath.Join(tempDir, "test.yaml")
+	err = os.WriteFile(yamlPath, []byte(yamlContent), 0644)
+	assert.NilError(t, err)
+
+	result, err = Load(yamlPath)
+	assert.NilError(t, err)
+	resultMap, ok = result.(map[string]interface{})
+	assert.Assert(t, ok, "expected map[string]interface{} for YAML result")
+	assert.Equal(t, "test", resultMap["name"])
+	assert.Equal(t, "hello", resultMap["string_value"])
+
+	// Test 3: Load multi-document YAML file
+	multiYAMLContent := `---
+name: test1
+string_value: hello
+---
+name: test2
+string_value: world
+`
+	multiYAMLPath := filepath.Join(tempDir, "multi.yaml")
+	err = os.WriteFile(multiYAMLPath, []byte(multiYAMLContent), 0644)
+	assert.NilError(t, err)
+
+	result, err = Load(multiYAMLPath)
+	assert.NilError(t, err)
+	resultArray, ok := result.([]interface{})
+	assert.Assert(t, ok, "expected []interface{} for multi-doc YAML result")
+	assert.Equal(t, 2, len(resultArray))
+
+	doc1, ok := resultArray[0].(map[string]interface{})
+	assert.Assert(t, ok, "expected map[string]interface{} for first YAML doc")
+	assert.Equal(t, "test1", doc1["name"])
+	assert.Equal(t, "hello", doc1["string_value"])
+
+	doc2, ok := resultArray[1].(map[string]interface{})
+	assert.Assert(t, ok, "expected map[string]interface{} for second YAML doc")
+	assert.Equal(t, "test2", doc2["name"])
+	assert.Equal(t, "world", doc2["string_value"])
+
+	// Test 4: File not found error
+	_, err = Load(filepath.Join(tempDir, "nonexistent.json"))
+	assert.Assert(t, err != nil, "expected error for nonexistent file")
+
+	// Test 5: Unrecognized format error
+	txtPath := filepath.Join(tempDir, "test.txt")
+	err = os.WriteFile(txtPath, []byte("plain text"), 0644)
+	assert.NilError(t, err)
+
+	_, err = Load(txtPath)
+	assert.Assert(t, err != nil, "expected error for unrecognized format")
+	assert.Assert(t, err.Error() != "", "error message should not be empty")
+
+	// Test 6: Invalid JSON format
+	invalidJSONPath := filepath.Join(tempDir, "invalid.json")
+	err = os.WriteFile(invalidJSONPath, []byte(`{"name": "test", invalid}`), 0644)
+	assert.NilError(t, err)
+
+	_, err = Load(invalidJSONPath)
+	assert.Assert(t, err != nil, "expected error for invalid JSON")
+
+	// Test 7: Invalid YAML format
+	invalidYAMLPath := filepath.Join(tempDir, "invalid.yaml")
+	err = os.WriteFile(invalidYAMLPath, []byte(`name: test
+  value: - invalid`), 0644)
+	assert.NilError(t, err)
+
+	_, err = Load(invalidYAMLPath)
+	assert.Assert(t, err != nil, "expected error for invalid YAML")
+}

--- a/pkg/server/playground/handler.go
+++ b/pkg/server/playground/handler.go
@@ -12,8 +12,39 @@ import (
 	jsonengine "github.com/kyverno/kyverno-json/pkg/json-engine"
 	"github.com/kyverno/kyverno-json/pkg/server/model"
 	"github.com/loopfz/gadgeto/tonic"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 )
+
+// Initialize a mock ConfigMapClient when the playground handler is created
+func init() {
+	// Use a mock implementation of the ConfigMapClient for playground
+	// This way users can test policies that use ConfigMap references in the playground
+	// without needing a real Kubernetes cluster
+	jsonengine.SetConfigMapClient(&mockConfigMapClient{})
+}
+
+// mockConfigMapClient is a simple implementation of the ConfigMapClient interface
+// that returns a predefined response for playground use
+type mockConfigMapClient struct{}
+
+// Get returns a mock ConfigMap for playground use
+func (m *mockConfigMapClient) Get(ctx context.Context, name, namespace string) (*v1.ConfigMap, error) {
+	// For playground purposes, return a mock ConfigMap with some sample data
+	// This allows testing policies with ConfigMap references
+	return &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: map[string]string{
+			"key1":      "value1",
+			"key2":      "value2",
+			"allowList": "item1,item2,item3",
+		},
+	}, nil
+}
 
 func newHandler() (gin.HandlerFunc, error) {
 	return tonic.Handler(func(ctx *gin.Context, in *Request) (*model.Response, error) {

--- a/test/commands/scan/jp/configmap-payload.json
+++ b/test/commands/scan/jp/configmap-payload.json
@@ -1,0 +1,11 @@
+{
+  "app": {
+    "name": "my-app",
+    "environment": "production",
+    "version": "1.0.0"
+  },
+  "user": {
+    "id": "12345",
+    "role": "admin"
+  }
+} 

--- a/test/commands/scan/jp/configmap.yaml
+++ b/test/commands/scan/jp/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: json.kyverno.io/v1alpha1
+kind: ValidatingPolicy
+metadata:
+  name: test-configmap
+spec:
+  rules:
+    - name: check-value-from-configmap
+      context:
+      - name: appConfig
+        configMap:
+          name: app-config
+          namespace: default
+      assert:
+        all:
+        - check:
+            app.environment: "{{ appConfig.data.environment }}" 


### PR DESCRIPTION
## Explanation

This PR adds support for ConfigMap context entries in kyverno-json, allowing policies to directly reference data stored in Kubernetes ConfigMaps. This enhances policy flexibility by externalizing configuration values into ConfigMaps that can be updated independently of the policies themselves, making policies more reusable and adaptable to different environments.

## Related issue

Closes #462

## What type of PR is this

/kind feature

## Proposed Changes

- Added `ConfigMapReference` type and `ConfigMap` field to the `ContextEntry` API
- Created a ConfigMap client to fetch ConfigMap data from the Kubernetes API server
- Updated the JSON engine compiler to handle ConfigMap references in context entries
- Initialized ConfigMap client in the serve command
- Added a mock ConfigMap client for playground mode for testing without a Kubernetes cluster
- Added comprehensive unit tests for the ConfigMap functionality

### Proof Manifests

# ConfigMap resource

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: app-config
  namespace: default
data:
  environment: "production"
  maxReplicas: "5"
  allowedEnvironments: "dev,staging,production"
```

# Validating policy using ConfigMap

```yaml
apiVersion: json.kyverno.io/v1alpha1
kind: ValidatingPolicy
metadata:
  name: configmap-example
spec:
  rules:
    - name: check-with-configmap
      context:
      - name: appConfig
        configMap:
          name: app-config
          namespace: default
      - name: allowedEnvs
        variable: "{{ appConfig.data.allowedEnvironments.split(',') }}"
      assert:
        all:
        - check:
            app.environment: "in {{ allowedEnvs }}"
```

# Sample payload

```json
{
  "app": {
    "name": "my-app",
    "environment": "production",
    "version": "1.0.0"
  }
}
```

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/kyverno/kyverno/blob/main/CONTRIBUTING.md).
- [x] I have read the [PR documentation guide](https://github.com/kyverno/kyverno/blob/main/.github/pr_documentation.md) and followed the process including adding proof manifests to this PR.
- [ ] This is a bug fix and I have added unit tests that prove my fix is effective.
- [x] This is a feature and I have added CLI tests that are applicable.
- [ ] My PR needs to be cherry picked to a specific release branch which is <replace>.

## Further Comments

The ConfigMap structure is accessed using the following pattern:
- `configMapName.data.<key>` to access ConfigMap data fields
- `configMapName.metadata.name` and `configMapName.metadata.namespace` to access metadata

The ConfigMap client is initialized in the serve command, and a mock version is used in playground mode to enable testing without requiring a real Kubernetes cluster.